### PR TITLE
[isuue-5] : 스플래시 화면에서 타이틀 텍스트가 가운데 정렬 안되는 현상 #5

### DIFF
--- a/lib/common/ui/screens/splash_screen.dart
+++ b/lib/common/ui/screens/splash_screen.dart
@@ -73,15 +73,18 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
                                 const SizedBox(
                                   height: 14,
                                 ),
-                                TypeWriter.text(
-                                  AppString.splashTitle,
-                                  duration: const Duration(milliseconds: 100),
-                                  softWrap: false,
-                                  textAlign: TextAlign.center,
-                                  style: const TextStyle(
-                                      fontSize: 24,
-                                      color: AppColor.color_000000,
-                                      fontWeight: FontWeight.w500),
+                                SizedBox(
+                                  width: double.infinity,
+                                  child: TypeWriter.text(
+                                    AppString.splashTitle,
+                                    duration: const Duration(milliseconds: 150),
+                                    softWrap: false,
+                                    alignment: Alignment.center,
+                                    style: const TextStyle(
+                                        fontSize: 24,
+                                        color: AppColor.color_000000,
+                                        fontWeight: FontWeight.w500),
+                                  ),
                                 ),
                               ],
                             ),


### PR DESCRIPTION
 - 텍스트 영역이 가로 전체를 차지하도록 변경